### PR TITLE
fix: Retain premium access after cancellation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -56,8 +56,10 @@ class User(UserMixin, db.Model):
 
     @property
     def active_subscription(self):
+        # A subscription is considered active for feature access if it's in 'active' or 'cancelled' state
+        # and its end date has not yet passed.
         return self.subscriptions.filter(
-            Subscription.status == 'active',
+            Subscription.status.in_(['active', 'cancelled']),
             Subscription.end_date > datetime.utcnow()
         ).order_by(Subscription.end_date.desc()).first()
 


### PR DESCRIPTION
This commit fixes a bug in the subscription cancellation logic. Previously, when a user cancelled their subscription, their access to premium features was immediately revoked.

The `User.active_subscription` property has been updated to correctly identify a subscription as valid as long as its end date has not passed and its status is either 'active' or 'cancelled'. This ensures that users who cancel their subscription will continue to have premium access for the remainder of the period they have paid for.