### PR TITLE
fix: Remove obsolete field from admin plan form template

### DIFF
--- a/app/templates/admin/plan_form.html
+++ b/app/templates/admin/plan_form.html
@@ -29,13 +29,6 @@
                 {% endfor %}
             </div>
             <div class="form-group">
-                {{ form.paystack_plan_code.label }}
-                {{ form.paystack_plan_code(class="form-control") }}
-                {% for error in form.paystack_plan_code.errors %}
-                <span style="color: red;">[{{ error }}]</span>
-                {% endfor %}
-            </div>
-            <div class="form-group">
                 {{ form.submit(class="btn") }}
                 <a href="{{ url_for('admin.plans') }}" style="margin-left: 1rem;">Cancel</a>
             </div>


### PR DESCRIPTION
This commit removes the `paystack_plan_code` field from the `plan_form.html` template.

The field was removed from the `PlanForm` object in a previous commit, but was not removed from the template, causing a `jinja2.exceptions.UndefinedError`. This commit corrects the template to align with the form definition.